### PR TITLE
Symfony 3 support using request_stack instead of request

### DIFF
--- a/Analytics.php
+++ b/Analytics.php
@@ -371,7 +371,7 @@ class Analytics
      */
     public function getRequest()
     {
-        return $this->container->get('request');
+        return $this->container->get('request_stack')->getCurrentRequest();
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     ],
     "require": {
         "php":             ">=5.3.0",
-        "symfony/symfony": ">=2.1"
+        "symfony/symfony": ">=2.4"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
Getting the request directly from the container is no longer possible, you need to use the RequestStack