### PR TITLE
fix upload path after target-dir was removed

### DIFF
--- a/Maps/StaticMap.php
+++ b/Maps/StaticMap.php
@@ -231,7 +231,7 @@ class StaticMap extends AbstractMap
 
     protected function getUploadRootDir()
     {
-        return __DIR__ . '/../../../../../../web/' . self::CACHE_DIR;
+        return __DIR__ . '/../../../../web/' . self::CACHE_DIR;
     }
 
     public function setHost($host)


### PR DESCRIPTION
After #3 was merged with `target-dir` being removed upload dir got broken. Not the best but the simplest solution