### PR TITLE
bugfix: pageview without dimension

### DIFF
--- a/Resources/views/Analytics/async_ua.html.twig
+++ b/Resources/views/Analytics/async_ua.html.twig
@@ -15,13 +15,14 @@
         ga('create', '{{ tracker.accountId }}', {% if tracker.crossDomain is defined %}'auto', {'name': '{{ google_analytics.trackerName(key)|trim('.') }}', 'allowLinker': true}{% else %}'{{ tracker.domain }}',{'name': '{{ google_analytics.trackerName(key)|trim('.') }}'}{% endif %});
         ga('{{ google_analytics.trackerName(key) }}require', 'displayfeatures');
         ga('{{ google_analytics.trackerName(key) }}set', 'anonymizeIp', {% if tracker.anonymizeIp %}true{% else %}false{% endif %});
-        ga('{{ google_analytics.trackerName(key) }}send', 'pageview');
-
+        
         {% if google_analytics.hasCustomVariables %}
             {% for customVariable in google_analytics.customVariables %}
                 ga('{{ google_analytics.trackerName(key) }}set', 'dimension{{customVariable.index}}', '{{ customVariable.value }}');
             {% endfor %}
         {% endif %}
+        
+        ga('{{ google_analytics.trackerName(key) }}send', 'pageview');
 
         {% if google_analytics.isTransactionValid %}
             ga('{{ google_analytics.trackerName(key) }}require', 'ecommerce', 'ecommerce.js');


### PR DESCRIPTION
according to the documentation ( https://support.google.com/analytics/answer/2709828#collection ) we should set the dimension bevor sending the pageview. otherwise the custom dimension would not have the data.